### PR TITLE
fix(WheelPad): 修复弹出轮盘按键发送过快导致的吞键问题

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
@@ -671,7 +671,14 @@ public class WheelPad extends Element {
                             handler.sendEvent(true);
                         }
 
-                        // 加入 30 毫秒延迟后再发送释放事件，防止按键时间过短被游戏忽略\n                        if (!handlers.isEmpty()) {\n                            elementController.getHandler().postDelayed(() -> {\n                                for (int i = handlers.size() - 1; i >= 0; i--) {\n                                    handlers.get(i).sendEvent(false);\n                                }\n                            }, 30); // 30 毫秒的持续时间\n                        }
+                        // 加入 30 毫秒延迟后再发送释放事件，防止按键时间过短被游戏忽略
+                        if (!handlers.isEmpty()) {
+                            elementController.getHandler().postDelayed(() -> {
+                                for (int i = handlers.size() - 1; i >= 0; i--) {
+                                    handlers.get(i).sendEvent(false);
+                                }
+                            }, 30); // 30 毫秒的持续时间
+                        }
                     }
                     isWheelActive = false;
                     activeIndex = -1;

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
@@ -671,12 +671,7 @@ public class WheelPad extends Element {
                             handler.sendEvent(true);
                         }
 
-                        // 加入 30 毫秒延迟后再发送释放事件，防止按键时间过短被游戏忽略
-                        new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(() -> {
-                            for (int i = handlers.size() - 1; i >= 0; i--) {
-                                handlers.get(i).sendEvent(false);
-                            }
-                        }, 30); // 30 毫秒的持续时间
+                        // 加入 30 毫秒延迟后再发送释放事件，防止按键时间过短被游戏忽略\n                        if (!handlers.isEmpty()) {\n                            elementController.getHandler().postDelayed(() -> {\n                                for (int i = handlers.size() - 1; i >= 0; i--) {\n                                    handlers.get(i).sendEvent(false);\n                                }\n                            }, 30); // 30 毫秒的持续时间\n                        }
                     }
                     isWheelActive = false;
                     activeIndex = -1;

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java
@@ -670,10 +670,13 @@ public class WheelPad extends Element {
                         for (ElementController.SendEventHandler handler : handlers) {
                             handler.sendEvent(true);
                         }
-                        // 释放
-                        for (int i = handlers.size() - 1; i >= 0; i--) {
-                            handlers.get(i).sendEvent(false);
-                        }
+
+                        // 加入 30 毫秒延迟后再发送释放事件，防止按键时间过短被游戏忽略
+                        new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(() -> {
+                            for (int i = handlers.size() - 1; i >= 0; i--) {
+                                handlers.get(i).sendEvent(false);
+                            }
+                        }, 30); // 30 毫秒的持续时间
                     }
                     isWheelActive = false;
                     activeIndex = -1;


### PR DESCRIPTION
【问题描述】
在弹出轮盘模式下（设置了中心文字），松开手指选中分区时，代码同步发送了 true 和 false 状态，中间 0ms 间隔导致串流端或游戏底层轮询无法识别到此次输入。

【解决方案】
在 WheelPad 的 MotionEvent.ACTION_UP 逻辑中，为按键释放（sendEvent(false)）添加了 30ms 的延迟，模拟真实手指点击的时长，确保按键指令能被游戏稳定接收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup-mode wheel release handling by scheduling the wheel button release with a brief delay on the main thread, making interactions feel more consistent.
  * Kept the same release ordering and cleanup behavior while softening abrupt release timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->