### PR TITLE
feat(crown): make crown_profiles and crown_layout one-time menus

### DIFF
--- a/app/src/main/java/com/limelight/CrownSessionController.kt
+++ b/app/src/main/java/com/limelight/CrownSessionController.kt
@@ -32,7 +32,7 @@ class CrownSessionController(
         when (backKeyMenuMode) {
             Game.BackKeyMenuMode.GAME_MENU -> enterCrownMode()
             Game.BackKeyMenuMode.CROWN_MODE -> exitCrownMode()
-            Game.BackKeyMenuMode.NO_MENU -> backKeyMenuMode = Game.BackKeyMenuMode.GAME_MENU
+            Game.BackKeyMenuMode.NO_MENU, Game.BackKeyMenuMode.NO_MENU_LOCKED -> backKeyMenuMode = Game.BackKeyMenuMode.GAME_MENU
         }
     }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -209,12 +209,14 @@ class Game : Activity(), SurfaceHolder.Callback,
     private var audioRenderer: com.limelight.binding.audio.SmartAudioRenderer? = null
 
     enum class BackKeyMenuMode {
-        GAME_MENU, CROWN_MODE, NO_MENU
+        GAME_MENU, CROWN_MODE, NO_MENU, NO_MENU_LOCKED
     }
 
     fun setcurrentBackKeyMenu(currentBackKeyMenu: BackKeyMenuMode) {
         crownSessionController.setBackKeyMenuMode(currentBackKeyMenu)
     }
+
+    fun getCurrentBackKeyMenuMode(): BackKeyMenuMode = crownSessionController.backKeyMenuMode
 
     fun toggleVirtualControllerVisibility() {
         crownSessionController.toggleElementsVisibility()
@@ -2152,7 +2154,12 @@ class Game : Activity(), SurfaceHolder.Callback,
                     controllerManager?.superPagesController?.returnOperation()
                 }
             }
-            BackKeyMenuMode.NO_MENU -> {}
+            BackKeyMenuMode.NO_MENU -> {
+                if (controllerManager != null && prefConfig.enableCrownFeatures) {
+                    controllerManager?.superPagesController?.returnOperation()
+                }
+            }
+            BackKeyMenuMode.NO_MENU_LOCKED -> {}
             BackKeyMenuMode.GAME_MENU -> {
                 activeGameMenu = GameMenu(this, app, conn!!, device)
             }

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -2155,7 +2155,7 @@ class Game : Activity(), SurfaceHolder.Callback,
                 }
             }
             BackKeyMenuMode.NO_MENU -> {
-                if (controllerManager != null && prefConfig.enableCrownFeatures) {
+                if (prefConfig.enableCrownFeatures) {
                     controllerManager?.superPagesController?.returnOperation()
                 }
             }

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -444,8 +444,7 @@ class GameMenu(
                 getString(R.string.crown_control_profiles_subtitle)
             ) {
                 controllerManager?.let { cm ->
-                    game.toggleBackKeyMenuType()
-                    game.setcurrentBackKeyMenu(Game.BackKeyMenuMode.NO_MENU)
+                    game.setcurrentBackKeyMenu(Game.BackKeyMenuMode.NO_MENU_LOCKED)
                     cm.pageConfigController?.open()
                 }
             },
@@ -456,8 +455,14 @@ class GameMenu(
             ) {
                 controllerManager?.let { cm ->
                     game.toggleBackKeyMenuType()
+                    game.setcurrentBackKeyMenu(Game.BackKeyMenuMode.NO_MENU)
                     cm.elementController?.changeMode(ElementController.Mode.Edit)
                     cm.elementController?.open()
+                    cm.superPagesController?.let { spc ->
+                        if (spc.pageNow === spc.pageNull) {
+                            spc.returnOperation()
+                        }
+                    }
                 }
             },
             createCrownOption(

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -357,15 +357,6 @@ class GameMenu(
                 ) {
                     setCrownFeatureEnabled(true)
                     replaceCrownFunctionMenu()
-                },
-                createCrownOption(
-                    getString(R.string.game_menu_configure_settings),
-                    "crown_profiles",
-                    getString(R.string.crown_control_profiles_subtitle)
-                ) {
-                    setCrownFeatureEnabled(true)
-                    game.setcurrentBackKeyMenu(Game.BackKeyMenuMode.NO_MENU)
-                    game.controllerManager?.pageConfigController?.open()
                 }
             )
             showSubMenu(getString(R.string.game_menu_crown_function_title), disabledOptions)

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
@@ -157,8 +157,12 @@ public class PageConfigController {
         pageConfig.findViewById(R.id.exit_crown_config_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // 保存/关闭配置页后继续保留王冠返回菜单模式
-                ((Game)context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
+                // 一次性模式（NO_MENU_LOCKED）退出后回到游戏菜单，否则保持王冠模式
+                if (((Game)context).getCurrentBackKeyMenuMode() == Game.BackKeyMenuMode.NO_MENU_LOCKED) {
+                    ((Game)context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.GAME_MENU);
+                } else {
+                    ((Game)context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
+                }
 
                 // 关闭当前的高级设置页面，相当于按返回键
                 controllerManager.getSuperPagesController().returnOperation();

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -272,8 +272,12 @@ public class ElementController {
             public void onClick(View v) {
                 changeMode(Mode.Normal);
                 controllerManager.pageSuperMenuController.open();
-                // 退出编辑模式后继续保留王冠返回菜单模式
-                ((Game) context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
+                // 一次性模式（NO_MENU）退出后回到游戏菜单，否则保持王冠模式
+                if (((Game) context).getCurrentBackKeyMenuMode() == Game.BackKeyMenuMode.NO_MENU) {
+                    ((Game) context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.GAME_MENU);
+                } else {
+                    ((Game) context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
+                }
             }
         });
         pageEdit.findViewById(R.id.page_edit_auto_color_all).setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
优化页面导航逻辑：配置页新增 `NO_MENU_LOCKED` 模式（禁用返回键）；编辑页改为 `NO_MENU` 模式（返回键切换显示）。退出时统一返回 `GAME_MENU`，修复了此前会残留 `CROWN_MODE` 的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated back-key menu mode to preserve an intentionally hidden menu state and restore the correct navigation context.

* **Bug Fixes**
  * Improved back-key menu behavior across game and crown/config screens to return users to the expected menu.
  * Updated crown option actions so “back key menu” handling matches the intended locked/hidden behavior.
  * Fixed layout-related navigation so the correct return action occurs when the active page is null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->